### PR TITLE
fix: reset pagination to the first page when applying filters in mult…

### DIFF
--- a/src/app/components/solicitudes-multimedia/solicitudes-multimedia.component.ts
+++ b/src/app/components/solicitudes-multimedia/solicitudes-multimedia.component.ts
@@ -188,6 +188,7 @@ export class SolicitudesMultimediaComponent implements OnInit, OnChanges {
         (filtroGeneral ? this.coincideFiltroGeneral(solicitud, filtroGeneral) : true)
       );
     });
+    this.pagina = 1;
   }
 
   coincideFiltroGeneral(solicitud: any, filtro: string): boolean {


### PR DESCRIPTION
This pull request introduces a minor update to the `SolicitudesMultimediaComponent` to improve the behavior when filtering data. Now, whenever the filter is applied, the pagination resets to the first page, ensuring users always see the beginning of the filtered results.

* Pagination reset:
  * [`src/app/components/solicitudes-multimedia/solicitudes-multimedia.component.ts`](diffhunk://#diff-4b3eebf71c5041c00f3ff615474b7a786e8766b41b101f1bcf7cbced45b6ca12R191): Reset `pagina` to 1 after applying filters so that filtered results always start from the first page.