### PR TITLE
Desarrollo

### DIFF
--- a/src/app/core/enums/session-error.enum.ts
+++ b/src/app/core/enums/session-error.enum.ts
@@ -178,13 +178,6 @@ export function getSessionErrorMessage(
         icon: 'error',
       };
 
-    case SessionErrorCode.NO_TOKEN:
-      return {
-        title: '🔐 Autenticación requerida',
-        message: 'No has iniciado sesión. Por favor inicia sesión para continuar.',
-        icon: 'info',
-      };
-
     default:
       return {
         title: '🔒 Sesión terminada',

--- a/src/app/core/enums/session-error.enum.ts
+++ b/src/app/core/enums/session-error.enum.ts
@@ -172,16 +172,12 @@ export function getSessionErrorMessage(
       };
 
     case SessionErrorCode.SESSION_NOT_FOUND:
-      return {
-        title: '❌ Sesión inválida',
-        message: 'Tu sesión no es válida. Por favor inicia sesión nuevamente.',
-        icon: 'error',
-      };
-
+    case SessionErrorCode.NO_TOKEN:
     default:
+      // Estos casos no muestran modal, redirigen directamente
       return {
-        title: '🔒 Sesión terminada',
-        message: 'Tu sesión ha finalizado. Por favor inicia sesión nuevamente.',
+        title: '',
+        message: '',
         icon: 'info',
       };
   }

--- a/src/app/core/interceptors/session/session.interceptor.ts
+++ b/src/app/core/interceptors/session/session.interceptor.ts
@@ -66,6 +66,12 @@ function handleSessionError(code: SessionErrorCode, router: Router, errorRespons
     return;
   }
 
+  // Para SESSION_REPLACED sin información de nueva sesión, redirigir directamente
+  if (code === SessionErrorCode.SESSION_REPLACED && !errorResponse?.newSessionInfo) {
+    clearSessionAndRedirect(router, code);
+    return;
+  }
+
   const { title, message, icon } = getSessionErrorMessage(code, errorResponse);
 
   // Mostrar mensaje al usuario con auto-cierre a los 10 segundos

--- a/src/app/core/interceptors/session/session.interceptor.ts
+++ b/src/app/core/interceptors/session/session.interceptor.ts
@@ -60,6 +60,12 @@ export const sessionInterceptor: HttpInterceptorFn = (req, next) => {
  * Maneja el error de sesión: muestra mensaje, limpia storage y redirige
  */
 function handleSessionError(code: SessionErrorCode, router: Router, errorResponse?: SessionErrorResponse): void {
+  // Para SESSION_NOT_FOUND y NO_TOKEN, redirigir directamente sin mostrar modal
+  if (code === SessionErrorCode.SESSION_NOT_FOUND || code === SessionErrorCode.NO_TOKEN) {
+    clearSessionAndRedirect(router, code);
+    return;
+  }
+
   const { title, message, icon } = getSessionErrorMessage(code, errorResponse);
 
   // Mostrar mensaje al usuario con auto-cierre a los 10 segundos


### PR DESCRIPTION
This pull request updates session error handling to improve user experience by streamlining how certain session errors are managed. Now, for specific session errors, the application redirects the user directly instead of displaying a modal message.

**Session error handling improvements:**

* In `session.interceptor.ts`, the `handleSessionError` function now directly redirects the user (without showing a modal) for `SESSION_NOT_FOUND` and `NO_TOKEN` errors, as well as for `SESSION_REPLACED` when no new session info is provided.
* In `session-error.enum.ts`, the modal messages for `SESSION_NOT_FOUND` and `NO_TOKEN` have been removed; these cases now return empty titles and messages, reflecting that no modal will be shown.