### PR TITLE
Desarrollo

### DIFF
--- a/src/app/core/guards/roles/roles.guard.ts
+++ b/src/app/core/guards/roles/roles.guard.ts
@@ -18,8 +18,9 @@ export class RolesGuard {
   checkUserLogin(route: ActivatedRouteSnapshot): boolean {
     let tienePermiso = false;
     const permisos = this.usuarioService.role;
-
+    console.log('Permisos del usuario:', permisos);
     for (let [index, permiso] of route.data['role'].entries()) {
+      console.log(`Verificando permiso requerido: ${permiso} contra permisos del usuario...`);
       const permisosUsuario = permisos.find((permisoAEncontrar: string) => permiso.toUpperCase() === permisoAEncontrar);
 
       if (permisosUsuario) {

--- a/src/app/core/interceptors/session/session.interceptor.ts
+++ b/src/app/core/interceptors/session/session.interceptor.ts
@@ -41,9 +41,17 @@ export const sessionInterceptor: HttpInterceptorFn = (req, next) => {
 
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
-      // No procesar errores de endpoints excluidos
+      // Para endpoints excluidos, sanitizar el mensaje de error
       if (isExcluded) {
-        return throwError(() => error);
+        // Crear un error sanitizado sin la URL completa
+        const sanitizedError = new HttpErrorResponse({
+          error: error.error,
+          headers: error.headers,
+          status: error.status,
+          statusText: error.statusText,
+          url: undefined, // Eliminar URL del mensaje de error
+        });
+        return throwError(() => sanitizedError);
       }
 
       // Solo procesar errores 401 (Unauthorized)

--- a/src/app/core/interfaces/seccion-home.interface.ts
+++ b/src/app/core/interfaces/seccion-home.interface.ts
@@ -18,6 +18,7 @@ export const generarSeccionHome: SeccionHomeInterface[] = [
     logo: 'assets/images/vista-principal/logo-multimedia.png',
     role: [
       ROLES.ADMINISTRADOR,
+      ROLES.ADMINISTRADOR_PAIS,
       ROLES.SUPERVISOR,
       ROLES.SUPERVISOR_LOCAL,
       ROLES.OBRERO_PAIS,
@@ -36,6 +37,7 @@ export const generarSeccionHome: SeccionHomeInterface[] = [
     ruta: `../${RUTAS.CENSO}`,
     role: [
       ROLES.ADMINISTRADOR,
+      ROLES.ADMINISTRADOR_PAIS,
       ROLES.SUPERVISOR,
       ROLES.SUPERVISOR_LOCAL,
       ROLES.OBRERO_PAIS,
@@ -98,6 +100,6 @@ export const generarSeccionHome: SeccionHomeInterface[] = [
     email: '',
     logo: 'assets/images/vista-principal/dashboard.png',
     ruta: `../${RUTAS.DASHBOARD_OBRERO}`,
-    role: [ROLES.ADMINISTRADOR, ROLES.OBRERO_PAIS, ROLES.OBRERO_CIUDAD, ROLES.OBRERO_CAMPO],
+    role: [ROLES.ADMINISTRADOR, ROLES.ADMINISTRADOR_PAIS, ROLES.OBRERO_PAIS, ROLES.OBRERO_CIUDAD, ROLES.OBRERO_CAMPO],
   },
 ];

--- a/src/app/core/models/congregacion-pais.model.ts
+++ b/src/app/core/models/congregacion-pais.model.ts
@@ -4,6 +4,7 @@ export class CongregacionPaisModel {
     public pais: string,
     public estado: boolean,
     public idDivisa?: number,
-    public idObreroEncargado?: number
+    public idObreroEncargado?: number,
+    public idAdministrador?: number,
   ) {}
 }

--- a/src/app/core/utils/error-sanitizer.utils.ts
+++ b/src/app/core/utils/error-sanitizer.utils.ts
@@ -1,0 +1,65 @@
+import { HttpErrorResponse } from '@angular/common/http';
+
+/**
+ * Sanitiza mensajes de error HTTP eliminando URLs sensibles de la API
+ * @param error Error HTTP o cualquier error
+ * @returns Mensaje sanitizado sin URLs
+ */
+export function sanitizeErrorMessage(error: any): string {
+  if (!error) {
+    return 'Error desconocido';
+  }
+
+  // Si es un HttpErrorResponse
+  if (error instanceof HttpErrorResponse) {
+    const statusCode = error.status;
+    const statusText = error.statusText || 'Error';
+
+    // Extraer solo el endpoint sin la URL completa
+    let endpoint = 'API';
+    if (error.url) {
+      try {
+        const url = new URL(error.url);
+        endpoint = url.pathname; // Solo la ruta sin dominio
+      } catch {
+        endpoint = 'API';
+      }
+    }
+
+    // Construir mensaje sin revelar URL completa
+    return `Error ${statusCode}: ${statusText} en ${endpoint}`;
+  }
+
+  // Si es un error con mensaje
+  if (error.message) {
+    // Eliminar URLs del mensaje usando regex
+    return error.message.replace(/https?:\/\/[^\s]+/gi, '[API]');
+  }
+
+  // Fallback
+  return String(error).replace(/https?:\/\/[^\s]+/gi, '[API]');
+}
+
+/**
+ * Versión simplificada que solo retorna el código de estado
+ * @param error Error HTTP
+ * @returns Mensaje simple con solo status code
+ */
+export function getErrorStatusMessage(error: HttpErrorResponse): string {
+  return `Error HTTP ${error.status}: ${error.statusText || 'Error en la petición'}`;
+}
+
+/**
+ * Console.error seguro que sanitiza el error antes de mostrarlo
+ * @param prefix Prefijo del mensaje
+ * @param error Error a mostrar
+ */
+export function safeConsoleError(prefix: string, error: any): void {
+  const sanitized = sanitizeErrorMessage(error);
+  console.error(`${prefix}:`, sanitized);
+
+  // En desarrollo, mostrar detalles adicionales sin la URL
+  if (error instanceof HttpErrorResponse && error.error) {
+    console.error('Detalles del error:', error.error);
+  }
+}

--- a/src/app/pages/administracion/pais/crear-pais/crear-pais.component.html
+++ b/src/app/pages/administracion/pais/crear-pais/crear-pais.component.html
@@ -35,6 +35,43 @@
             </select>
           </div>
 
+          <div class="form-group">
+            <label class="col-form-label">Administrador (Número Mita)</label>
+            <input
+              type="number"
+              formControlName="idAdministrador"
+              class="form-control"
+              placeholder="Ingrese el número Mita del administrador"
+              min="1"
+              (blur)="buscarAdministrador()"
+              (keyup.enter)="buscarAdministrador()"
+            />
+            <small class="form-text text-muted"> Deje vacío si no desea asignar un administrador </small>
+
+            <!-- Mensaje de cargando -->
+            @if (buscandoAdministrador) {
+              <div class="alert alert-info mt-2 mb-0" role="alert">
+                <i class="fa fa-spinner fa-spin"></i> Buscando administrador...
+              </div>
+            }
+
+            <!-- Mostrar nombre del administrador encontrado -->
+            @if (administradorEncontrado && !buscandoAdministrador) {
+              <div class="alert alert-success mt-2 mb-0" role="alert">
+                <i class="fa fa-check-circle"></i>
+                <strong>{{ getNombreAdministrador() }}</strong>
+              </div>
+            }
+
+            <!-- Error si no se encuentra el administrador -->
+            @if (errorBusquedaAdministrador && !buscandoAdministrador) {
+              <div class="alert alert-danger mt-2 mb-0" role="alert">
+                <i class="fa fa-exclamation-triangle"></i>
+                No se encontró un usuario con el número Mita ingresado
+              </div>
+            }
+          </div>
+
           <div class="card">
             <button type="submit" class="submit btn btn-primary" (click)="crearPais()">
               <i class="fa fa-save"></i> Guardar

--- a/src/app/pages/administracion/pais/crear-pais/crear-pais.component.html
+++ b/src/app/pages/administracion/pais/crear-pais/crear-pais.component.html
@@ -2,13 +2,19 @@
   <div class="col-md-6">
     <div class="card">
       <div class="card-header">
-        <h3 class="card-title">Nuevo País</h3>
+        <h3 class="card-title">{{ paisSeleccionado ? 'Editar País' : 'Nuevo País' }}</h3>
       </div>
       <div class="card-body">
         <form class="form-signin" autocomplete="off" [formGroup]="paisForm">
           <div class="form-group">
             <label>País:</label>
-            <input type="text" formControlName="pais" class="form-control" placeholder="Digite un país nuevo" />
+            <input
+              type="text"
+              formControlName="pais"
+              class="form-control"
+              placeholder="Digite un país nuevo"
+              [readonly]="usuarioService.isAdministradorPais"
+            />
           </div>
 
           <!-- <div class="form-group">
@@ -23,7 +29,11 @@
 
           <div class="form-group">
             <label class="col-form-label">Obrero Encargado</label>
-            <select class="form-control" formControlName="idObreroEncargado">
+            <select
+              class="form-control"
+              formControlName="idObreroEncargado"
+              [disabled]="usuarioService.isAdministradorPais"
+            >
               <option value="" disabled>Seleccione el obrero encargado</option>
               <option [ngValue]="null">Sin obrero Asignado</option>
               @for (obrero of obreros; track obrero) {

--- a/src/app/pages/administracion/pais/crear-pais/crear-pais.component.ts
+++ b/src/app/pages/administracion/pais/crear-pais/crear-pais.component.ts
@@ -28,7 +28,7 @@ export class CrearPaisComponent implements OnInit, OnDestroy {
   private router = inject(Router);
   private paisService = inject(PaisService);
   private divisaService = inject(DivisaService);
-  private usuarioService = inject(UsuarioService);
+  public usuarioService = inject(UsuarioService);
   private activatedRoute = inject(ActivatedRoute);
 
   public paisForm: FormGroup;
@@ -78,9 +78,25 @@ export class CrearPaisComponent implements OnInit, OnDestroy {
   }
 
   cargarPaises() {
-    this.paisSubscription = this.paisService.getPaises().subscribe((pais: CongregacionPaisModel[]) => {
-      this.paises = pais.filter((pais) => pais.estado === true);
-    });
+    // Si es ADMINISTRADOR_PAIS, solo cargar su país asignado
+    if (this.usuarioService.isAdministradorPais) {
+      const idUsuario = this.usuarioService.usuario.id;
+      this.paisSubscription = this.paisService.getPaisPorAdministrador(idUsuario).subscribe(
+        (pais: CongregacionPaisModel) => {
+          // Convertir el país único en un array
+          this.paises = pais && pais.estado ? [pais] : [];
+        },
+        (error) => {
+          console.error('Error al cargar país del administrador:', error);
+          this.paises = [];
+        },
+      );
+    } else {
+      // Para otros roles, cargar todos los países activos
+      this.paisSubscription = this.paisService.getPaises().subscribe((pais: CongregacionPaisModel[]) => {
+        this.paises = pais.filter((pais) => pais.estado === true);
+      });
+    }
   }
 
   crearPais() {

--- a/src/app/pages/administracion/pais/crear-pais/crear-pais.component.ts
+++ b/src/app/pages/administracion/pais/crear-pais/crear-pais.component.ts
@@ -3,46 +3,48 @@ import { FormBuilder, FormGroup, Validators, FormsModule, ReactiveFormsModule } 
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { delay } from 'rxjs/operators';
-import { ListarUsuario } from 'src/app/core/interfaces/usuario.interface';
 import { DivisaModel } from 'src/app/core/models/divisa.model';
 import { CongregacionPaisModel } from 'src/app/core/models/congregacion-pais.model';
+import { UsuarioInterface } from 'src/app/core/interfaces/usuario.interface';
 import { UsuarioModel } from 'src/app/core/models/usuario.model';
 import { RUTAS } from 'src/app/routes/menu-items';
 import { DivisaService } from 'src/app/services/divisa/divisa.service';
 import { PaisService } from 'src/app/services/pais/pais.service';
 import { UsuarioService } from 'src/app/services/usuario/usuario.service';
 import Swal from 'sweetalert2';
-import { ObreroInterface, ObreroModel } from 'src/app/core/models/obrero.model';
+import { ObreroInterface } from 'src/app/core/models/obrero.model';
 import { NgxIntlTelInputModule } from 'ngx-intl-tel-input';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-crear-pais',
   templateUrl: './crear-pais.component.html',
   styleUrls: ['./crear-pais.component.scss'],
   standalone: true,
-  imports: [FormsModule, ReactiveFormsModule, NgxIntlTelInputModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, NgxIntlTelInputModule],
 })
 export class CrearPaisComponent implements OnInit, OnDestroy {
   private formBuilder = inject(FormBuilder);
   private router = inject(Router);
   private paisService = inject(PaisService);
   private divisaService = inject(DivisaService);
-  private usuariosService = inject(UsuarioService);
+  private usuarioService = inject(UsuarioService);
   private activatedRoute = inject(ActivatedRoute);
 
   public paisForm: FormGroup;
 
   public paises: CongregacionPaisModel[] = [];
   public divisas: DivisaModel[] = [];
-  public usuarios: UsuarioModel[] = [];
   public obreros: ObreroInterface[] = [];
 
   public paisSeleccionado: CongregacionPaisModel;
+  public administradorEncontrado: UsuarioModel | null = null;
+  public buscandoAdministrador = false;
+  public errorBusquedaAdministrador = false;
 
   // Subscription
   public paisSubscription: Subscription;
   public divisaSubscription: Subscription;
-  public usuariosSubscription: Subscription;
 
   ngOnInit(): void {
     this.activatedRoute.params.subscribe(({ id }) => {
@@ -57,10 +59,6 @@ export class CrearPaisComponent implements OnInit, OnDestroy {
       this.divisas = divisa;
     });
 
-    this.usuariosSubscription = this.usuariosService.listarTodosLosUsuarios().subscribe((usuarios: ListarUsuario) => {
-      this.usuarios = usuarios.usuarios;
-    });
-
     this.cargarPaises();
     this.crearFormulario();
   }
@@ -68,7 +66,6 @@ export class CrearPaisComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.divisaSubscription?.unsubscribe();
     this.paisSubscription?.unsubscribe();
-    this.usuariosSubscription?.unsubscribe();
   }
 
   crearFormulario() {
@@ -76,6 +73,7 @@ export class CrearPaisComponent implements OnInit, OnDestroy {
       pais: ['', [Validators.required, Validators.minLength(3)]],
       idDivisa: [null, [Validators.required]],
       idObreroEncargado: [null],
+      idAdministrador: [null],
     });
   }
 
@@ -94,9 +92,17 @@ export class CrearPaisComponent implements OnInit, OnDestroy {
         id: this.paisSeleccionado.id,
       };
 
-      // Si idObreroEncargado es null, lo dejamos como null para que se actualice correctamente
-      if (data.idObreroEncargado === null) {
+      // Si idObreroEncargado es null o vacío, lo convertimos a null
+      if (!data.idObreroEncargado) {
         data.idObreroEncargado = null;
+      }
+
+      // Si idAdministrador es null, vacío o 0, lo convertimos a null
+      if (!data.idAdministrador || data.idAdministrador === 0) {
+        data.idAdministrador = null;
+      } else {
+        // Aseguramos que sea un número
+        data.idAdministrador = Number(data.idAdministrador);
       }
 
       this.paisService.actualizarPais(data).subscribe((pais: any) => {
@@ -105,10 +111,21 @@ export class CrearPaisComponent implements OnInit, OnDestroy {
           icon: 'success',
           html: `El país ${pais.paisActualizado.pais} se actualizó correctamente`,
         });
+        this.resetFormulario();
+        this.cargarPaises();
       });
-      this.resetFormulario();
-      this.cargarPaises();
     } else {
+      // Para crear país nuevo, también validamos el idAdministrador
+      if (!paisNuevo.idAdministrador || paisNuevo.idAdministrador === 0) {
+        paisNuevo.idAdministrador = null;
+      } else {
+        paisNuevo.idAdministrador = Number(paisNuevo.idAdministrador);
+      }
+
+      if (!paisNuevo.idObreroEncargado) {
+        paisNuevo.idObreroEncargado = null;
+      }
+
       this.paisService.crearPais(paisNuevo).subscribe(
         (paisCreado: any) => {
           Swal.fire('Pais creado', `${paisCreado.pais.pais}`, 'success');
@@ -143,10 +160,15 @@ export class CrearPaisComponent implements OnInit, OnDestroy {
       .pipe(delay(100))
       .subscribe(
         (paisEncontrado: CongregacionPaisModel) => {
-          const { pais, idObreroEncargado, idDivisa } = paisEncontrado;
+          const { pais, idObreroEncargado, idDivisa, idAdministrador } = paisEncontrado;
           this.paisSeleccionado = paisEncontrado;
 
-          this.paisForm.setValue({ pais, idDivisa, idObreroEncargado });
+          this.paisForm.setValue({ pais, idDivisa, idObreroEncargado, idAdministrador });
+
+          // Buscar el administrador si existe
+          if (idAdministrador) {
+            this.buscarAdministrador(idAdministrador);
+          }
         },
         (error) => {
           const errores = error.error.errors || [];
@@ -163,7 +185,52 @@ export class CrearPaisComponent implements OnInit, OnDestroy {
       );
   }
 
+  /**
+   * Busca el administrador por su número Mita y muestra su nombre
+   */
+  buscarAdministrador(numeroMita?: number): void {
+    const idAdministrador = numeroMita || this.paisForm.get('idAdministrador')?.value;
+
+    // Limpiar estado previo
+    this.administradorEncontrado = null;
+    this.errorBusquedaAdministrador = false;
+
+    // Si no hay número Mita, salir
+    if (!idAdministrador || idAdministrador === 0) {
+      return;
+    }
+
+    this.buscandoAdministrador = true;
+
+    this.usuarioService.getUsuario(Number(idAdministrador)).subscribe(
+      (response: UsuarioInterface) => {
+        this.administradorEncontrado = response.usuario;
+        this.buscandoAdministrador = false;
+        this.errorBusquedaAdministrador = false;
+      },
+      (error) => {
+        this.administradorEncontrado = null;
+        this.buscandoAdministrador = false;
+        this.errorBusquedaAdministrador = true;
+        console.error('Error al buscar administrador:', error);
+      },
+    );
+  }
+
+  /**
+   * Obtiene el nombre completo del administrador
+   */
+  getNombreAdministrador(): string {
+    if (!this.administradorEncontrado) return '';
+
+    const { primerNombre, segundoNombre, primerApellido, segundoApellido } = this.administradorEncontrado;
+    const nombre = [primerNombre, segundoNombre, primerApellido, segundoApellido].filter((n) => n).join(' ');
+    return nombre;
+  }
+
   resetFormulario() {
     this.paisForm.reset();
+    this.administradorEncontrado = null;
+    this.errorBusquedaAdministrador = false;
   }
 }

--- a/src/app/pages/administracion/pais/paises/paises.component.html
+++ b/src/app/pages/administracion/pais/paises/paises.component.html
@@ -1,155 +1,167 @@
 <section class="content">
   <!-- Cargado información -->
   @if (cargando) {
-  <app-cargando-informacion></app-cargando-informacion>
-  } @if (!cargando) {
-  <div class="card">
-    <div class="card-header d-flex justify-content-between align-items-center">
-      <div class="col-8 px-4 pt-4">
-        <h3 class="card-title">Paises ({{ paises.length }})</h3>
-        <p>Paises registrados en la aplicación</p>
-      </div>
-      <!-- empiezan botones -->
-      <div class="d-flex flex-wrap align-items-center gap-2">
-        <!-- Botón Crear País -->
-        <a class="btn btn-primary d-flex align-items-center" (click)="crearPais()">
-          <i class="fas fa-plus"></i>
-          <span class="d-none d-md-inline-block ms-2">Crear Congregación</span>
-        </a>
-
-        <!-- Botón Filtros -->
-        <button
-          class="btn d-flex align-items-center"
-          [ngClass]="{ 'btn-secondary': isFiltrosVisibles, 'btn-outline-secondary': !isFiltrosVisibles }"
-          (click)="esconderFiltros()"
-        >
-          <i class="fa fa-filter"></i>
-          <span class="d-none d-md-inline-block ms-2">
-            {{ isFiltrosVisibles ? 'Ocultar Filtros' : 'Ver Filtros' }}
-          </span>
-        </button>
-
-        <!-- Botón Exportar a Excel -->
-        <button
-          class="btn btn-outline-primary d-flex align-items-center"
-          (click)="exportarDatosFiltrados()"
-          title="Exportar a Excel"
-        >
-          <i class="fa fa-download" aria-hidden="true"></i>
-          <span class="d-none d-md-inline-block ms-2">Exportar</span>
-        </button>
-      </div>
-      <!-- terminan botones -->
-    </div>
-    <div class="card-body">
-      @if (isFiltrosVisibles) {
-      <div>
-        <!-- Campo de búsqueda -->
-        <!-- <app-filtros (onFiltroNombre)="obtenerFiltroNombre($event)"></app-filtros> -->
-        @if (paises.length > 0) {
-        <div class="card-body">
-          <div class="row">
-            <div class="col-lg-8 col-md-8 col-sm-8 col-xs-8">
-              <div class="form-group">
-                <label>Buscar</label>
-                <input
-                  type="search"
-                  class="form-control"
-                  [(ngModel)]="filterText"
-                  placeholder="Buscar por nombre u obrero..."
-                  name="filtro"
-                />
-              </div>
-            </div>
-
-            <div class="col-md-3 d-flex align-items-end">
-              <div class="form-group w-100">
-                <button class="btn btn-primary w-100" (click)="resetFiltros()">Reset Filtros</button>
-              </div>
-            </div>
-          </div>
+    <app-cargando-informacion></app-cargando-informacion>
+  }
+  @if (!cargando) {
+    <div class="card">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <div class="col-8 px-4 pt-4">
+          <h3 class="card-title">Paises ({{ paises.length }})</h3>
+          <p>Paises registrados en la aplicación</p>
         </div>
-        } @else {
-        <div class="card">
-          <div class="card-body">No existen feligreses registrados en su congregación a cargo</div>
+        <!-- empiezan botones -->
+        <div class="d-flex flex-wrap align-items-center gap-2">
+          <!-- Botón Crear País -->
+          <a class="btn btn-primary d-flex align-items-center" (click)="crearPais()">
+            <i class="fas fa-plus"></i>
+            <span class="d-none d-md-inline-block ms-2">Crear Congregación</span>
+          </a>
+
+          <!-- Botón Filtros -->
+          <button
+            class="btn d-flex align-items-center"
+            [ngClass]="{ 'btn-secondary': isFiltrosVisibles, 'btn-outline-secondary': !isFiltrosVisibles }"
+            (click)="esconderFiltros()"
+          >
+            <i class="fa fa-filter"></i>
+            <span class="d-none d-md-inline-block ms-2">
+              {{ isFiltrosVisibles ? 'Ocultar Filtros' : 'Ver Filtros' }}
+            </span>
+          </button>
+
+          <!-- Botón Exportar a Excel -->
+          <button
+            class="btn btn-outline-primary d-flex align-items-center"
+            (click)="exportarDatosFiltrados()"
+            title="Exportar a Excel"
+          >
+            <i class="fa fa-download" aria-hidden="true"></i>
+            <span class="d-none d-md-inline-block ms-2">Exportar</span>
+          </button>
         </div>
-        }
+        <!-- terminan botones -->
       </div>
-      }
+      <div class="card-body">
+        @if (isFiltrosVisibles) {
+          <div>
+            <!-- Campo de búsqueda -->
+            <!-- <app-filtros (onFiltroNombre)="obtenerFiltroNombre($event)"></app-filtros> -->
+            @if (paises.length > 0) {
+              <div class="card-body">
+                <div class="row">
+                  <div class="col-lg-8 col-md-8 col-sm-8 col-xs-8">
+                    <div class="form-group">
+                      <label>Buscar</label>
+                      <input
+                        type="search"
+                        class="form-control"
+                        [(ngModel)]="filterText"
+                        placeholder="Buscar por nombre, obrero o administrador..."
+                        name="filtro"
+                      />
+                    </div>
+                  </div>
 
-      <div class="table-responsive">
-        <table class="table table-bordered table-striped mx-auto">
-          <thead>
-            <tr>
-              <th>Item</th>
-              <th>Nombre</th>
-              <th>Obrero Encargado</th>
-              <th>Divisa</th>
-              <th>Estado</th>
-              <th>Acciones</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (pais of paisesFiltrados | filterByNombrePipe : 'pais' : filtroNombre; track pais; let i = $index) {
-            <tr>
-              <td>{{ i + 1 }}</td>
-              <td>{{ pais.pais }}</td>
-              <td>
-                {{ buscarObrero(pais.idObreroEncargado) }}
-
-                <span class="badge text-bg-primary">{{ pais.idObreroEncargado }}</span>
-              </td>
-              <td>{{ buscarDivisa(pais.idDivisa) }}</td>
-              <td>
-                @if (pais.estado) {
-                <span class="badge badge-primary">Activo</span>
-                } @if (!pais.estado) {
-                <span class="badge badge-danger">Deshabilitado</span>
-                }
-              </td>
-              <td>
-                @if (!!pais.estado) {
-                <a
-                  data-toggle="tooltip"
-                  data-original-title="Editar"
-                  class="btn bg-info"
-                  (click)="actualizarPais(pais.id)"
-                  ><i class="fas fa-pencil-alt ml-1"></i
-                ></a>
-                } @if (!!pais.estado) {
-                <a
-                  data-toggle="tooltip"
-                  data-original-title="Borrar"
-                  class="btn bg-danger ml-1"
-                  (click)="borrarPais(pais)"
-                  ><i class="fas fa-trash-alt"></i
-                ></a>
-                } @if (!pais.estado) {
-                <a
-                  data-toggle="tooltip"
-                  data-original-title="Activar"
-                  class="btn bg-secondary ml-1"
-                  (click)="activarPais(pais)"
-                  ><i class="fas fa-check-square"></i
-                ></a>
-                }
-              </td>
-            </tr>
+                  <div class="col-md-3 d-flex align-items-end">
+                    <div class="form-group w-100">
+                      <button class="btn btn-primary w-100" (click)="resetFiltros()">Reset Filtros</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            } @else {
+              <div class="card">
+                <div class="card-body">No existen feligreses registrados en su congregación a cargo</div>
+              </div>
             }
-          </tbody>
-          <tfoot>
-            <tr>
-              <th>Item</th>
-              <th>Nombre</th>
-              <th>Obrero Encargado</th>
-              <th>Divisa</th>
-              <th>Estado</th>
-              <th>Acciones</th>
-            </tr>
-          </tfoot>
-        </table>
+          </div>
+        }
+
+        <div class="table-responsive">
+          <table class="table table-bordered table-striped mx-auto">
+            <thead>
+              <tr>
+                <th>Item</th>
+                <th>Nombre</th>
+                <th>Obrero Encargado</th>
+                <th>Administrador</th>
+                <th>Divisa</th>
+                <th>Estado</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (pais of paisesFiltrados | filterByNombrePipe: 'pais' : filtroNombre; track pais; let i = $index) {
+                <tr>
+                  <td>{{ i + 1 }}</td>
+                  <td>{{ pais.pais }}</td>
+                  <td>
+                    {{ buscarObrero(pais.idObreroEncargado) }}
+
+                    <span class="badge text-bg-primary">{{ pais.idObreroEncargado }}</span>
+                  </td>
+                  <td>
+                    {{ buscarAdministrador(pais.idAdministrador) }}
+                    @if (pais.idAdministrador) {
+                      <span class="badge text-bg-info">{{ pais.idAdministrador }}</span>
+                    }
+                  </td>
+                  <td>{{ buscarDivisa(pais.idDivisa) }}</td>
+                  <td>
+                    @if (pais.estado) {
+                      <span class="badge badge-primary">Activo</span>
+                    }
+                    @if (!pais.estado) {
+                      <span class="badge badge-danger">Deshabilitado</span>
+                    }
+                  </td>
+                  <td>
+                    @if (!!pais.estado) {
+                      <a
+                        data-toggle="tooltip"
+                        data-original-title="Editar"
+                        class="btn bg-info"
+                        (click)="actualizarPais(pais.id)"
+                        ><i class="fas fa-pencil-alt ml-1"></i
+                      ></a>
+                    }
+                    @if (!!pais.estado) {
+                      <a
+                        data-toggle="tooltip"
+                        data-original-title="Borrar"
+                        class="btn bg-danger ml-1"
+                        (click)="borrarPais(pais)"
+                        ><i class="fas fa-trash-alt"></i
+                      ></a>
+                    }
+                    @if (!pais.estado) {
+                      <a
+                        data-toggle="tooltip"
+                        data-original-title="Activar"
+                        class="btn bg-secondary ml-1"
+                        (click)="activarPais(pais)"
+                        ><i class="fas fa-check-square"></i
+                      ></a>
+                    }
+                  </td>
+                </tr>
+              }
+            </tbody>
+            <tfoot>
+              <tr>
+                <th>Item</th>
+                <th>Nombre</th>
+                <th>Obrero Encargado</th>
+                <th>Administrador</th>
+                <th>Divisa</th>
+                <th>Estado</th>
+                <th>Acciones</th>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
       </div>
     </div>
-  </div>
   }
 </section>

--- a/src/app/pages/administracion/pais/paises/paises.component.html
+++ b/src/app/pages/administracion/pais/paises/paises.component.html
@@ -12,11 +12,13 @@
         </div>
         <!-- empiezan botones -->
         <div class="d-flex flex-wrap align-items-center gap-2">
-          <!-- Botón Crear País -->
-          <a class="btn btn-primary d-flex align-items-center" (click)="crearPais()">
-            <i class="fas fa-plus"></i>
-            <span class="d-none d-md-inline-block ms-2">Crear Congregación</span>
-          </a>
+          <!-- Botón Crear País - Solo visible para roles que no sean ADMINISTRADOR_PAIS -->
+          @if (!usuarioService.isAdministradorPais) {
+            <a class="btn btn-primary d-flex align-items-center" (click)="crearPais()">
+              <i class="fas fa-plus"></i>
+              <span class="d-none d-md-inline-block ms-2">Crear Congregación</span>
+            </a>
+          }
 
           <!-- Botón Filtros -->
           <button
@@ -126,7 +128,8 @@
                         ><i class="fas fa-pencil-alt ml-1"></i
                       ></a>
                     }
-                    @if (!!pais.estado) {
+                    <!-- Botones de Borrar y Activar solo para roles que no sean ADMINISTRADOR_PAIS -->
+                    @if (!!pais.estado && !usuarioService.isAdministradorPais) {
                       <a
                         data-toggle="tooltip"
                         data-original-title="Borrar"
@@ -135,7 +138,7 @@
                         ><i class="fas fa-trash-alt"></i
                       ></a>
                     }
-                    @if (!pais.estado) {
+                    @if (!pais.estado && !usuarioService.isAdministradorPais) {
                       <a
                         data-toggle="tooltip"
                         data-original-title="Activar"

--- a/src/app/pages/administracion/pais/paises/paises.component.ts
+++ b/src/app/pages/administracion/pais/paises/paises.component.ts
@@ -5,8 +5,10 @@ import { delay } from 'rxjs/operators';
 import { DivisaModel } from 'src/app/core/models/divisa.model';
 import { CongregacionPaisModel } from 'src/app/core/models/congregacion-pais.model';
 import { UsuarioModel } from 'src/app/core/models/usuario.model';
+import { ListarUsuario } from 'src/app/core/interfaces/usuario.interface';
 import { RUTAS } from 'src/app/routes/menu-items';
 import { PaisService } from 'src/app/services/pais/pais.service';
+import { UsuarioService } from 'src/app/services/usuario/usuario.service';
 import Swal from 'sweetalert2';
 
 import { CargandoInformacionComponent } from '../../../../components/cargando-informacion/cargando-informacion.component';
@@ -27,6 +29,7 @@ import { FormsModule } from '@angular/forms';
 export class PaisesComponent implements OnInit, OnDestroy {
   private router = inject(Router);
   private paisService = inject(PaisService);
+  private usuarioService = inject(UsuarioService);
   private activatedRoute = inject(ActivatedRoute);
   private exportarExcelService = inject(ExportarExcelService);
 
@@ -34,6 +37,7 @@ export class PaisesComponent implements OnInit, OnDestroy {
   paises: CongregacionPaisModel[] = [];
   divisas: DivisaModel[] = [];
   obreros: UsuarioModel[] = [];
+  usuarios: UsuarioModel[] = [];
 
   filtroNombre: string = '';
 
@@ -53,6 +57,11 @@ export class PaisesComponent implements OnInit, OnDestroy {
     this.activatedRoute.data.subscribe((data: { divisas: DivisaModel[]; obrero: UsuarioModel[] }) => {
       this.divisas = data.divisas;
       this.obreros = data.obrero;
+    });
+
+    // Cargar todos los usuarios para buscar administradores
+    this.usuarioService.listarTodosLosUsuarios().subscribe((response: ListarUsuario) => {
+      this.usuarios = response.usuarios;
     });
 
     this.cargarPaises();
@@ -151,6 +160,26 @@ export class PaisesComponent implements OnInit, OnDestroy {
     return nombreObrero;
   }
 
+  buscarAdministrador(idAdministrador: number | undefined): string {
+    if (!idAdministrador) {
+      return 'Sin administrador asignado';
+    }
+
+    let administrador = this.usuarios.find((usuario) => usuario.id === idAdministrador);
+
+    const nombreAdministrador = administrador
+      ? administrador?.primerNombre +
+        ' ' +
+        administrador?.segundoNombre +
+        ' ' +
+        administrador?.primerApellido +
+        ' ' +
+        administrador?.segundoApellido
+      : 'Sin administrador asignado';
+
+    return nombreAdministrador;
+  }
+
   obtenerFiltroNombre(nombre: string) {
     this.filtroNombre = nombre;
   }
@@ -160,6 +189,7 @@ export class PaisesComponent implements OnInit, OnDestroy {
       ID: pais.id,
       Nombre: pais.pais,
       Obrero: this.buscarObrero(pais.idObreroEncargado) || 'N/A',
+      Administrador: this.buscarAdministrador(pais.idAdministrador) || 'N/A',
       Divisa: this.buscarDivisa(pais.idDivisa),
     }));
     this.exportarExcelService.exportToExcel(datosParaExportar, this.nombreArchivo);
@@ -197,9 +227,12 @@ export class PaisesComponent implements OnInit, OnDestroy {
 
         const pais = this.normalizeString(getSafeString(country.pais));
         const obrero = this.normalizeString(getSafeString(this.buscarObrero(country.idObreroEncargado)));
+        const administrador = this.normalizeString(getSafeString(this.buscarAdministrador(country.idAdministrador)));
 
         // Filtrar el usuario si alguna de las propiedades contiene el término de búsqueda
-        return pais.includes(lowerFilterTerm) || obrero.includes(lowerFilterTerm);
+        return (
+          pais.includes(lowerFilterTerm) || obrero.includes(lowerFilterTerm) || administrador.includes(lowerFilterTerm)
+        );
       });
     }
   }

--- a/src/app/pages/administracion/pais/paises/paises.component.ts
+++ b/src/app/pages/administracion/pais/paises/paises.component.ts
@@ -29,7 +29,7 @@ import { FormsModule } from '@angular/forms';
 export class PaisesComponent implements OnInit, OnDestroy {
   private router = inject(Router);
   private paisService = inject(PaisService);
-  private usuarioService = inject(UsuarioService);
+  public usuarioService = inject(UsuarioService);
   private activatedRoute = inject(ActivatedRoute);
   private exportarExcelService = inject(ExportarExcelService);
 
@@ -73,14 +73,38 @@ export class PaisesComponent implements OnInit, OnDestroy {
 
   cargarPaises() {
     this.cargando = true;
-    this.paisSubscription = this.paisService
-      .getPaises()
-      .pipe(delay(100))
-      .subscribe((pais: CongregacionPaisModel[]) => {
-        this.paises = pais;
-        this.paisesFiltrados = pais;
-        this.cargando = false;
-      });
+
+    // Si es ADMINISTRADOR_PAIS, solo cargar su país asignado
+    if (this.usuarioService.isAdministradorPais) {
+      const idUsuario = this.usuarioService.usuario.id;
+      this.paisSubscription = this.paisService
+        .getPaisPorAdministrador(idUsuario)
+        .pipe(delay(100))
+        .subscribe(
+          (pais: CongregacionPaisModel) => {
+            // Convertir el país único en un array
+            this.paises = pais ? [pais] : [];
+            this.paisesFiltrados = this.paises;
+            this.cargando = false;
+          },
+          (error) => {
+            console.error('Error al cargar país del administrador:', error);
+            this.paises = [];
+            this.paisesFiltrados = [];
+            this.cargando = false;
+          },
+        );
+    } else {
+      // Para otros roles, cargar todos los países
+      this.paisSubscription = this.paisService
+        .getPaises()
+        .pipe(delay(100))
+        .subscribe((pais: CongregacionPaisModel[]) => {
+          this.paises = pais;
+          this.paisesFiltrados = pais;
+          this.cargando = false;
+        });
+    }
   }
 
   borrarPais(pais: CongregacionPaisModel) {

--- a/src/app/pages/administracion/pais/paises/paises.component.ts
+++ b/src/app/pages/administracion/pais/paises/paises.component.ts
@@ -88,7 +88,7 @@ export class PaisesComponent implements OnInit, OnDestroy {
             this.cargando = false;
           },
           (error) => {
-            console.error('Error al cargar país del administrador:', error);
+            console.error('Error al cargar país del administrador');
             this.paises = [];
             this.paisesFiltrados = [];
             this.cargando = false;

--- a/src/app/pages/dashboard-obrero/dashboard-obrero.component.html
+++ b/src/app/pages/dashboard-obrero/dashboard-obrero.component.html
@@ -591,7 +591,7 @@
               <!-- Columna Nombre -->
               <ng-container matColumnDef="nombre">
                 <th mat-header-cell *matHeaderCellDef mat-sort-header>Nombre</th>
-                <td mat-cell *matCellDef="let usuario">{{ obtenerNombreCompleto(usuario) }}</td>
+                <td mat-cell *matCellDef="let usuario">{{ getNombreCompleto(usuario) }}</td>
               </ng-container>
 
               <!-- Columna Email -->
@@ -616,8 +616,8 @@
               <ng-container matColumnDef="edad">
                 <th mat-header-cell *matHeaderCellDef mat-sort-header>Edad</th>
                 <td mat-cell *matCellDef="let usuario">
-                  @if (calcularEdad(usuario.fechaNacimiento) !== null) {
-                    {{ calcularEdad(usuario.fechaNacimiento) }} años
+                  @if (getEdad(usuario.fechaNacimiento) !== null) {
+                    {{ getEdad(usuario.fechaNacimiento) }} años
                     @if (usuario.esJoven) {
                       <mat-chip class="joven-chip">Joven</mat-chip>
                     }

--- a/src/app/pages/dashboard-obrero/dashboard-obrero.component.ts
+++ b/src/app/pages/dashboard-obrero/dashboard-obrero.component.ts
@@ -438,59 +438,22 @@ export class DashboardObreroComponent implements OnInit, AfterViewInit, OnDestro
     this.cargando.set(true);
     this.error.set(null);
 
-    // Si el usuario es ADMINISTRADOR_PAIS, primero obtener su país asignado
-    if (this.usuarioService.isAdministradorPais) {
-      this.paisService.getPaisPorAdministrador(obreroId).subscribe({
-        next: (pais: CongregacionPaisModel) => {
-          if (pais) {
-            // Cargar datos filtrando por el país
-            this.dashboardService.getUsuariosCompleto(obreroId).subscribe({
-              next: (response) => {
-                // Filtrar usuarios del país asignado
-                const usuariosFiltradosPorPais = (response.data || []).filter((usuario) => {
-                  return usuario.usuarioCongregacionPais?.some((p) => p.id === pais.id);
-                });
-                this.usuarios.set(usuariosFiltradosPorPais);
-                this.procesarDatos();
-                this.cargando.set(false);
-              },
-              error: (error) => {
-                console.error('Dashboard Obrero - Error al cargar datos:', error);
-                this.error.set(`Error al cargar los datos: ${error.message || 'Error desconocido'}`);
-                this.cargando.set(false);
-                this.mostrarError('Error al cargar los datos del dashboard');
-              },
-            });
-          } else {
-            this.error.set('No se encontró un país asignado como administrador');
-            this.cargando.set(false);
-            this.mostrarError('No se encontró un país asignado');
-          }
-        },
-        error: (error) => {
-          console.error('Error al obtener país del administrador:', error);
-          this.error.set('No se pudo cargar el país asignado');
-          this.cargando.set(false);
-          this.mostrarError('Error al cargar el país asignado');
-        },
-      });
-    } else {
-      // Comportamiento normal para otros roles
-      this.dashboardService.getUsuariosCompleto(obreroId).subscribe({
-        next: (response) => {
-          this.usuarios.set(response.data || []);
-          this.procesarDatos();
-          this.cargando.set(false);
-        },
-        error: (error) => {
-          console.error('Dashboard Obrero - Error al cargar datos:', error);
-          console.error('Dashboard Obrero - Error completo:', error);
-          this.error.set(`Error al cargar los datos: ${error.message || 'Error desconocido'}`);
-          this.cargando.set(false);
-          this.mostrarError('Error al cargar los datos del dashboard');
-        },
-      });
-    }
+    // El backend determina automáticamente si es administrador de país o no
+    // basándose en el idUsuario y sus permisos
+    this.dashboardService.getUsuariosCompleto(obreroId).subscribe({
+      next: (response) => {
+        this.usuarios.set(response.data || []);
+        this.procesarDatos();
+        this.cargando.set(false);
+      },
+      error: (error) => {
+        console.error('Dashboard Obrero - Error al cargar datos:', error);
+        console.error('Dashboard Obrero - Error completo:', error);
+        this.error.set(`Error al cargar los datos: ${error.message || 'Error desconocido'}`);
+        this.cargando.set(false);
+        this.mostrarError('Error al cargar los datos del dashboard');
+      },
+    });
   }
 
   /**

--- a/src/app/pages/dashboard-obrero/dashboard-obrero.component.ts
+++ b/src/app/pages/dashboard-obrero/dashboard-obrero.component.ts
@@ -447,9 +447,8 @@ export class DashboardObreroComponent implements OnInit, AfterViewInit, OnDestro
         this.cargando.set(false);
       },
       error: (error) => {
-        console.error('Dashboard Obrero - Error al cargar datos:', error);
-        console.error('Dashboard Obrero - Error completo:', error);
-        this.error.set(`Error al cargar los datos: ${error.message || 'Error desconocido'}`);
+        console.error('Dashboard Obrero - Error al cargar datos');
+        this.error.set('Error al cargar los datos del dashboard');
         this.cargando.set(false);
         this.mostrarError('Error al cargar los datos del dashboard');
       },

--- a/src/app/pages/dashboard-obrero/dashboard-obrero.component.ts
+++ b/src/app/pages/dashboard-obrero/dashboard-obrero.component.ts
@@ -39,6 +39,8 @@ import { NgxChartsModule } from '@swimlane/ngx-charts';
 // Services & Utils
 import { DashboardObreroService } from 'src/app/services/dashboard-obrero/dashboard-obrero.service';
 import { UsuarioService } from 'src/app/services/usuario/usuario.service';
+import { PaisService } from 'src/app/services/pais/pais.service';
+import { CongregacionPaisModel } from 'src/app/core/models/congregacion-pais.model';
 import {
   UsuarioCompleto,
   EstadisticasDashboard,
@@ -91,6 +93,7 @@ export class DashboardObreroComponent implements OnInit, AfterViewInit, OnDestro
   // Injects
   private dashboardService = inject(DashboardObreroService);
   private usuarioService = inject(UsuarioService);
+  private paisService = inject(PaisService);
   private fb = inject(FormBuilder);
   private router = inject(Router);
   private dialog = inject(MatDialog);
@@ -435,20 +438,59 @@ export class DashboardObreroComponent implements OnInit, AfterViewInit, OnDestro
     this.cargando.set(true);
     this.error.set(null);
 
-    this.dashboardService.getUsuariosCompleto(obreroId).subscribe({
-      next: (response) => {
-        this.usuarios.set(response.data || []);
-        this.procesarDatos();
-        this.cargando.set(false);
-      },
-      error: (error) => {
-        console.error('Dashboard Obrero - Error al cargar datos:', error);
-        console.error('Dashboard Obrero - Error completo:', error);
-        this.error.set(`Error al cargar los datos: ${error.message || 'Error desconocido'}`);
-        this.cargando.set(false);
-        this.mostrarError('Error al cargar los datos del dashboard');
-      },
-    });
+    // Si el usuario es ADMINISTRADOR_PAIS, primero obtener su país asignado
+    if (this.usuarioService.isAdministradorPais) {
+      this.paisService.getPaisPorAdministrador(obreroId).subscribe({
+        next: (pais: CongregacionPaisModel) => {
+          if (pais) {
+            // Cargar datos filtrando por el país
+            this.dashboardService.getUsuariosCompleto(obreroId).subscribe({
+              next: (response) => {
+                // Filtrar usuarios del país asignado
+                const usuariosFiltradosPorPais = (response.data || []).filter((usuario) => {
+                  return usuario.usuarioCongregacionPais?.some((p) => p.id === pais.id);
+                });
+                this.usuarios.set(usuariosFiltradosPorPais);
+                this.procesarDatos();
+                this.cargando.set(false);
+              },
+              error: (error) => {
+                console.error('Dashboard Obrero - Error al cargar datos:', error);
+                this.error.set(`Error al cargar los datos: ${error.message || 'Error desconocido'}`);
+                this.cargando.set(false);
+                this.mostrarError('Error al cargar los datos del dashboard');
+              },
+            });
+          } else {
+            this.error.set('No se encontró un país asignado como administrador');
+            this.cargando.set(false);
+            this.mostrarError('No se encontró un país asignado');
+          }
+        },
+        error: (error) => {
+          console.error('Error al obtener país del administrador:', error);
+          this.error.set('No se pudo cargar el país asignado');
+          this.cargando.set(false);
+          this.mostrarError('Error al cargar el país asignado');
+        },
+      });
+    } else {
+      // Comportamiento normal para otros roles
+      this.dashboardService.getUsuariosCompleto(obreroId).subscribe({
+        next: (response) => {
+          this.usuarios.set(response.data || []);
+          this.procesarDatos();
+          this.cargando.set(false);
+        },
+        error: (error) => {
+          console.error('Dashboard Obrero - Error al cargar datos:', error);
+          console.error('Dashboard Obrero - Error completo:', error);
+          this.error.set(`Error al cargar los datos: ${error.message || 'Error desconocido'}`);
+          this.cargando.set(false);
+          this.mostrarError('Error al cargar los datos del dashboard');
+        },
+      });
+    }
   }
 
   /**
@@ -861,7 +903,7 @@ export class DashboardObreroComponent implements OnInit, AfterViewInit, OnDestro
       'Primer Apellido': u.primerApellido || '',
       'Segundo Apellido': u.segundoApellido || '',
       Apodo: u.apodo || '',
-      'Nombre Completo': obtenerNombreCompleto(u),
+      'Nombre Completo': this.getNombreCompleto(u),
 
       // Contacto
       Email: u.email || '',
@@ -871,7 +913,7 @@ export class DashboardObreroComponent implements OnInit, AfterViewInit, OnDestro
 
       // Información demográfica
       'Fecha Nacimiento': u.fechaNacimiento || '',
-      Edad: calcularEdad(u.fechaNacimiento) || '',
+      Edad: this.getEdad(u.fechaNacimiento) || '',
       'Es Joven': u.esJoven ? 'Sí' : 'No',
       Género: u.genero?.genero || '',
       'Estado Civil': u.estadoCivil?.estadoCivil || '',
@@ -943,7 +985,7 @@ export class DashboardObreroComponent implements OnInit, AfterViewInit, OnDestro
    */
   verDetalle(usuario: UsuarioCompleto): void {
     // Aquí puedes abrir un modal o navegar a una ruta de detalle
-    this.mostrarInformacion(`Detalle de ${obtenerNombreCompleto(usuario)}`);
+    this.mostrarInformacion(`Detalle de ${this.getNombreCompleto(usuario)}`);
 
     // Ejemplo: navegación a ruta de detalle
     // this.router.navigate(['/dashboard/obrero/usuarios', usuario.id]);
@@ -959,10 +1001,23 @@ export class DashboardObreroComponent implements OnInit, AfterViewInit, OnDestro
     }
   }
 
-  // Helpers para el template
-  obtenerNombreCompleto = obtenerNombreCompleto;
-  calcularEdad = calcularEdad;
+  /**
+   * Obtiene el nombre completo de un usuario (wrapper para el template)
+   */
+  getNombreCompleto(usuario: UsuarioCompleto): string {
+    return obtenerNombreCompleto(usuario);
+  }
 
+  /**
+   * Calcula la edad de un usuario (wrapper para el template)
+   */
+  getEdad(fechaNacimiento: string): number | null {
+    return calcularEdad(fechaNacimiento);
+  }
+
+  /**
+   * Obtiene la congregación de un usuario
+   */
   obtenerCongregacion(usuario: UsuarioCompleto): string {
     return usuario.usuarioCongregacionCongregacion?.[0]?.congregacion || 'Sin congregación';
   }

--- a/src/app/pages/obreros/censo-obrero/censo-obrero.component.ts
+++ b/src/app/pages/obreros/censo-obrero/censo-obrero.component.ts
@@ -56,42 +56,25 @@ export default class CensoObreroComponent implements OnInit, OnDestroy {
   cargarUsuarios() {
     this.cargando = true;
 
-    // Si el usuario es ADMINISTRADOR_PAIS, filtrar por su país asignado
-    if (this.usuarioService.isAdministradorPais) {
-      // Primero obtener el país donde es administrador
-      this.paisService.getPaisPorAdministrador(this.idUsuario).subscribe({
-        next: (pais: CongregacionPaisModel) => {
-          if (pais) {
-            // Cargar usuarios del país
-            this.usuarioSubscription = this.usuariosPorCongregacionService
-              .listarUsuariosPorPais(this.idUsuario)
-              .subscribe(({ totalUsuarios, usuarios }) => {
-                this.totalUsuarios = totalUsuarios;
-                this.usuarios = usuarios;
-                this.congregacion = pais.pais; // Actualizar nombre de congregación a nombre del país
-                this.cargando = false;
-              });
-          } else {
-            Swal.fire('Error', 'No se encontró un país asignado como administrador', 'error');
-            this.cargando = false;
-          }
-        },
-        error: (error) => {
-          console.error('Error al obtener país del administrador:', error);
-          Swal.fire('Error', 'No se pudo cargar el país asignado', 'error');
-          this.cargando = false;
-        },
-      });
-    } else {
-      // Comportamiento normal: filtrar por congregación
-      this.usuarioSubscription = this.usuariosPorCongregacionService
-        .listarUsuariosPorCongregacion(this.idUsuario)
-        .subscribe(({ totalUsuarios, usuarios }) => {
-          this.totalUsuarios = totalUsuarios;
-          this.usuarios = usuarios;
-          this.cargando = false;
-        });
-    }
+    // Si el usuario es ADMINISTRADOR_PAIS, cargar usuarios del país
+    // De lo contrario, cargar usuarios de la congregación
+    // El backend determina automáticamente según el idUsuario y sus permisos
+    const metodoLlamada = this.usuarioService.isAdministradorPais
+      ? this.usuariosPorCongregacionService.listarUsuariosPorPais(this.idUsuario)
+      : this.usuariosPorCongregacionService.listarUsuariosPorCongregacion(this.idUsuario);
+
+    this.usuarioSubscription = metodoLlamada.subscribe({
+      next: ({ totalUsuarios, usuarios }) => {
+        this.totalUsuarios = totalUsuarios;
+        this.usuarios = usuarios;
+        this.cargando = false;
+      },
+      error: (error) => {
+        console.error('Error al cargar usuarios:', error);
+        Swal.fire('Error', 'No se pudo cargar el censo', 'error');
+        this.cargando = false;
+      },
+    });
   }
 
   borrarUsuario(usuario: UsuariosPorCongregacionInterface) {

--- a/src/app/pages/obreros/censo-obrero/censo-obrero.component.ts
+++ b/src/app/pages/obreros/censo-obrero/censo-obrero.component.ts
@@ -70,7 +70,7 @@ export default class CensoObreroComponent implements OnInit, OnDestroy {
         this.cargando = false;
       },
       error: (error) => {
-        console.error('Error al cargar usuarios:', error);
+        console.error('Error al cargar usuarios del censo');
         Swal.fire('Error', 'No se pudo cargar el censo', 'error');
         this.cargando = false;
       },

--- a/src/app/pages/obreros/censo-obrero/censo-obrero.component.ts
+++ b/src/app/pages/obreros/censo-obrero/censo-obrero.component.ts
@@ -8,6 +8,8 @@ import { RUTAS } from 'src/app/routes/menu-items';
 import { UsuarioService } from 'src/app/services/usuario/usuario.service';
 import { UsuariosPorCongregacionService } from 'src/app/services/usuarios-por-congregacion/usuarios-por-congregacion.service';
 import { EnviarCorreoService } from 'src/app/services/enviar-correo/enviar-correo.service';
+import { PaisService } from 'src/app/services/pais/pais.service';
+import { CongregacionPaisModel } from 'src/app/core/models/congregacion-pais.model';
 
 import { CargandoInformacionComponent } from '../../../components/cargando-informacion/cargando-informacion.component';
 import { VerCensoComponent } from '../../../components/ver-censo/ver-censo.component';
@@ -24,6 +26,7 @@ export default class CensoObreroComponent implements OnInit, OnDestroy {
   private usuarioService = inject(UsuarioService);
   private usuariosPorCongregacionService = inject(UsuariosPorCongregacionService);
   private enviarCorreoService = inject(EnviarCorreoService);
+  private paisService = inject(PaisService);
 
   totalUsuarios: number = 0;
   usuarios: UsuariosPorCongregacionInterface[] = [];
@@ -52,13 +55,43 @@ export default class CensoObreroComponent implements OnInit, OnDestroy {
 
   cargarUsuarios() {
     this.cargando = true;
-    this.usuarioSubscription = this.usuariosPorCongregacionService
-      .listarUsuariosPorCongregacion(this.idUsuario)
-      .subscribe(({ totalUsuarios, usuarios }) => {
-        this.totalUsuarios = totalUsuarios;
-        this.usuarios = usuarios;
-        this.cargando = false;
+
+    // Si el usuario es ADMINISTRADOR_PAIS, filtrar por su país asignado
+    if (this.usuarioService.isAdministradorPais) {
+      // Primero obtener el país donde es administrador
+      this.paisService.getPaisPorAdministrador(this.idUsuario).subscribe({
+        next: (pais: CongregacionPaisModel) => {
+          if (pais) {
+            // Cargar usuarios del país
+            this.usuarioSubscription = this.usuariosPorCongregacionService
+              .listarUsuariosPorPais(this.idUsuario)
+              .subscribe(({ totalUsuarios, usuarios }) => {
+                this.totalUsuarios = totalUsuarios;
+                this.usuarios = usuarios;
+                this.congregacion = pais.pais; // Actualizar nombre de congregación a nombre del país
+                this.cargando = false;
+              });
+          } else {
+            Swal.fire('Error', 'No se encontró un país asignado como administrador', 'error');
+            this.cargando = false;
+          }
+        },
+        error: (error) => {
+          console.error('Error al obtener país del administrador:', error);
+          Swal.fire('Error', 'No se pudo cargar el país asignado', 'error');
+          this.cargando = false;
+        },
       });
+    } else {
+      // Comportamiento normal: filtrar por congregación
+      this.usuarioSubscription = this.usuariosPorCongregacionService
+        .listarUsuariosPorCongregacion(this.idUsuario)
+        .subscribe(({ totalUsuarios, usuarios }) => {
+          this.totalUsuarios = totalUsuarios;
+          this.usuarios = usuarios;
+          this.cargando = false;
+        });
+    }
   }
 
   borrarUsuario(usuario: UsuariosPorCongregacionInterface) {
@@ -80,7 +113,7 @@ export default class CensoObreroComponent implements OnInit, OnDestroy {
           Swal.fire(
             '¡Deshabilitado!',
             `${usuario.primerNombre} ${usuario.primerApellido} fue deshabilitado correctamente`,
-            'success'
+            'success',
           );
 
           this.cargarUsuarios();
@@ -109,7 +142,7 @@ export default class CensoObreroComponent implements OnInit, OnDestroy {
           Swal.fire(
             '¡Activado!',
             `El usuario ${usuarioEncontrado.primerNombre} ${usuarioEncontrado.segundoNombre} ${usuarioEncontrado.primerApellido} fue activado correctamente`,
-            'success'
+            'success',
           );
           this.cargarUsuarios();
         });
@@ -125,7 +158,7 @@ export default class CensoObreroComponent implements OnInit, OnDestroy {
           congregacion_id: data.congregacion,
           campo_id: data.campo,
         },
-        data.id
+        data.id,
       )
       .subscribe({
         next: () => {

--- a/src/app/routes/child-routes/child.routes.ts
+++ b/src/app/routes/child-routes/child.routes.ts
@@ -160,6 +160,7 @@ export const childRoutes: Routes = [
       titulo: 'Censo',
       role: [
         ROLES.ADMINISTRADOR,
+        ROLES.ADMINISTRADOR_PAIS,
         ROLES.SUPERVISOR,
         ROLES.SUPERVISOR_LOCAL,
         ROLES.OBRERO_PAIS,
@@ -556,6 +557,7 @@ export const childRoutes: Routes = [
     data: {
       role: [
         ROLES.ADMINISTRADOR,
+        ROLES.ADMINISTRADOR_PAIS,
         ROLES.SUPERVISOR,
         ROLES.SUPERVISOR_LOCAL,
         ROLES.OBRERO_PAIS,
@@ -573,6 +575,7 @@ export const childRoutes: Routes = [
       titulo: 'Dashboard de Obrero',
       role: [
         ROLES.ADMINISTRADOR,
+        ROLES.ADMINISTRADOR_PAIS,
         ROLES.SUPERVISOR,
         ROLES.SUPERVISOR_LOCAL,
         ROLES.OBRERO_PAIS,

--- a/src/app/routes/child-routes/child.routes.ts
+++ b/src/app/routes/child-routes/child.routes.ts
@@ -226,14 +226,34 @@ export const childRoutes: Routes = [
   {
     path: RUTAS.PAISES,
     component: PaisesComponent,
-    data: { titulo: 'Paises' },
+    canActivate: [RolesGuard],
+    data: {
+      titulo: 'Paises',
+      role: [
+        ROLES.ADMINISTRADOR,
+        ROLES.ADMINISTRADOR_PAIS,
+        ROLES.SUPERVISOR,
+        ROLES.SUPERVISOR_LOCAL,
+        ROLES.ASISTENTE_OOTS,
+      ],
+    },
     resolve: { divisas: DivisasResolver, obrero: ObreroResolver },
   },
   {
     path: `${RUTAS.PAISES}/:id`,
     component: CrearPaisComponent,
+    canActivate: [RolesGuard],
     resolve: { divisas: DivisasResolver, obrero: ObreroResolver },
-    data: { titulo: 'Crear Pais' },
+    data: {
+      titulo: 'Crear Pais',
+      role: [
+        ROLES.ADMINISTRADOR,
+        ROLES.ADMINISTRADOR_PAIS,
+        ROLES.SUPERVISOR,
+        ROLES.SUPERVISOR_LOCAL,
+        ROLES.ASISTENTE_OOTS,
+      ],
+    },
   },
   {
     path: RUTAS.CONGREGACIONES,

--- a/src/app/routes/menu-items.ts
+++ b/src/app/routes/menu-items.ts
@@ -76,6 +76,7 @@ export enum RUTAS {
 
 export enum ROLES {
   ADMINISTRADOR = 'ADMINISTRADOR',
+  ADMINISTRADOR_PAIS = 'ADMINISTRADOR PAIS',
   SUPERVISOR = 'SUPERVISOR',
   SUPERVISOR_LOCAL = 'SUPERVISOR LOCAL',
   OBRERO_PAIS = 'OBRERO PAÍS',
@@ -402,7 +403,14 @@ export const ROUTES: RouteInfo[] = [
     icon: 'fa fa-users',
     class: 'has-arrow',
     extralink: false,
-    role: [ROLES.ADMINISTRADOR, ROLES.ASISTENTE_OOTS, ROLES.OBRERO_PAIS, ROLES.OBRERO_CIUDAD, ROLES.OBRERO_CAMPO],
+    role: [
+      ROLES.ADMINISTRADOR,
+      ROLES.ADMINISTRADOR_PAIS,
+      ROLES.ASISTENTE_OOTS,
+      ROLES.OBRERO_PAIS,
+      ROLES.OBRERO_CIUDAD,
+      ROLES.OBRERO_CAMPO,
+    ],
     submenu: [],
   },
   {
@@ -411,7 +419,7 @@ export const ROUTES: RouteInfo[] = [
     icon: 'fa fa-chart-bar',
     class: 'has-arrow',
     extralink: false,
-    role: [ROLES.OBRERO_CIUDAD, ROLES.OBRERO_CAMPO, ROLES.OBRERO_PAIS],
+    role: [ROLES.ADMINISTRADOR_PAIS, ROLES.OBRERO_CIUDAD, ROLES.OBRERO_CAMPO, ROLES.OBRERO_PAIS],
     submenu: [],
   },
   {
@@ -624,6 +632,7 @@ export const ROUTES: RouteInfo[] = [
     extralink: true,
     role: [
       ROLES.ADMINISTRADOR,
+      ROLES.ADMINISTRADOR_PAIS,
       ROLES.SUPERVISOR,
       ROLES.SUPERVISOR_LOCAL,
       ROLES.ASISTENTE_OOTS,
@@ -643,6 +652,7 @@ export const ROUTES: RouteInfo[] = [
     extralink: false,
     role: [
       ROLES.ADMINISTRADOR,
+      ROLES.ADMINISTRADOR_PAIS,
       ROLES.SUPERVISOR,
       ROLES.SUPERVISOR_LOCAL,
       ROLES.ASISTENTE_OOTS,
@@ -661,6 +671,7 @@ export const ROUTES: RouteInfo[] = [
         extralink: false,
         role: [
           ROLES.ADMINISTRADOR,
+          ROLES.ADMINISTRADOR_PAIS,
           ROLES.SUPERVISOR,
           ROLES.SUPERVISOR_LOCAL,
           ROLES.ASISTENTE_OOTS,

--- a/src/app/routes/menu-items.ts
+++ b/src/app/routes/menu-items.ts
@@ -76,7 +76,7 @@ export enum RUTAS {
 
 export enum ROLES {
   ADMINISTRADOR = 'ADMINISTRADOR',
-  ADMINISTRADOR_PAIS = 'ADMINISTRADOR PAIS',
+  ADMINISTRADOR_PAIS = 'ADMINISTRADOR PAÍS',
   SUPERVISOR = 'SUPERVISOR',
   SUPERVISOR_LOCAL = 'SUPERVISOR LOCAL',
   OBRERO_PAIS = 'OBRERO PAÍS',
@@ -100,6 +100,7 @@ export const ROUTES: RouteInfo[] = [
     class: 'nav-small-cap',
     role: [
       ROLES.ADMINISTRADOR,
+      ROLES.ADMINISTRADOR_PAIS,
       ROLES.SUPERVISOR,
       ROLES.SUPERVISOR_LOCAL,
       ROLES.OBRERO_PAIS,
@@ -121,6 +122,7 @@ export const ROUTES: RouteInfo[] = [
     extralink: false,
     role: [
       ROLES.ADMINISTRADOR,
+      ROLES.ADMINISTRADOR_PAIS,
       ROLES.SUPERVISOR,
       ROLES.SUPERVISOR_LOCAL,
       ROLES.OBRERO_PAIS,
@@ -692,6 +694,7 @@ export const ROUTES: RouteInfo[] = [
         extralink: false,
         role: [
           ROLES.ADMINISTRADOR,
+          ROLES.ADMINISTRADOR_PAIS,
           ROLES.OBRERO_PAIS,
           ROLES.OBRERO_CIUDAD,
           ROLES.OBRERO_CAMPO,
@@ -706,7 +709,7 @@ export const ROUTES: RouteInfo[] = [
         icon: '',
         class: '',
         extralink: false,
-        role: [ROLES.OBRERO_PAIS, ROLES.OBRERO_CIUDAD, ROLES.OBRERO_CAMPO],
+        role: [ROLES.ADMINISTRADOR_PAIS, ROLES.OBRERO_PAIS, ROLES.OBRERO_CIUDAD, ROLES.OBRERO_CAMPO],
         submenu: [],
       },
       {
@@ -717,6 +720,7 @@ export const ROUTES: RouteInfo[] = [
         extralink: false,
         role: [
           ROLES.ADMINISTRADOR,
+          ROLES.ADMINISTRADOR_PAIS,
           ROLES.OBRERO_PAIS,
           ROLES.OBRERO_CIUDAD,
           ROLES.OBRERO_CAMPO,

--- a/src/app/services/dashboard-obrero/dashboard-obrero.service.ts
+++ b/src/app/services/dashboard-obrero/dashboard-obrero.service.ts
@@ -27,11 +27,11 @@ export class DashboardObreroService {
 
   /**
    * Obtiene los usuarios completos para el dashboard de obrero
-   * @param obreroId ID del obrero
+   * @param idUsuario ID del usuario (obrero o administrador)
    * @returns Observable con la respuesta del endpoint
    */
-  getUsuariosCompleto(obreroId: number): Observable<DashboardObreroResponse> {
-    const url = `${base_url}/usuarios/completo?obreroId=${obreroId}`;
+  getUsuariosCompleto(idUsuario: number): Observable<DashboardObreroResponse> {
+    const url = `${base_url}/usuarios/completo?idUsuario=${idUsuario}`;
 
     return this.httpClient.get<DashboardObreroResponse>(url, this.headers).pipe(
       map((response) => {

--- a/src/app/services/dashboard-obrero/dashboard-obrero.service.ts
+++ b/src/app/services/dashboard-obrero/dashboard-obrero.service.ts
@@ -4,6 +4,7 @@ import { Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { environment } from 'environment';
 import { DashboardObreroResponse } from 'src/app/core/interfaces/dashboard-obrero.interface';
+import { safeConsoleError } from 'src/app/core/utils/error-sanitizer.utils';
 
 const base_url = environment.base_url;
 
@@ -38,10 +39,7 @@ export class DashboardObreroService {
         return response;
       }),
       catchError((error: HttpErrorResponse) => {
-        console.error('Dashboard Service - Error HTTP:', error);
-        console.error('Dashboard Service - Status:', error.status);
-        console.error('Dashboard Service - Message:', error.message);
-        console.error('Dashboard Service - Error completo:', error.error);
+        safeConsoleError('Dashboard Service - Error HTTP', error);
         return throwError(() => error);
       }),
     );

--- a/src/app/services/pais/pais.service.ts
+++ b/src/app/services/pais/pais.service.ts
@@ -50,4 +50,15 @@ export class PaisService {
   activarPais(pais: CongregacionPaisModel) {
     return this.httpClient.put(`${base_url}/pais/activar/${pais.id}`, pais, this.headers);
   }
+
+  /**
+   * Obtiene el país donde el usuario es administrador
+   * @param idUsuario ID del usuario
+   * @returns Observable con el país donde el usuario es administrador
+   */
+  getPaisPorAdministrador(idUsuario: number) {
+    return this.httpClient
+      .get(`${base_url}/pais/administrador/${idUsuario}`, this.headers)
+      .pipe(map((respuesta: { ok: boolean; pais: CongregacionPaisModel }) => respuesta.pais));
+  }
 }

--- a/src/app/services/usuario/usuario.service.ts
+++ b/src/app/services/usuario/usuario.service.ts
@@ -83,6 +83,14 @@ export class UsuarioService {
     });
   }
 
+  /**
+   * Verifica si el usuario tiene el rol ADMINISTRADOR_PAIS
+   * @returns true si el usuario tiene el rol ADMINISTRADOR_PAIS, false en caso contrario
+   */
+  get isAdministradorPais(): boolean {
+    return this.role.includes('ADMINISTRADOR PAIS');
+  }
+
   get isQRLogin() {
     return sessionStorage.getItem('isQRLogin') === 'isQRLogin';
   }


### PR DESCRIPTION
This pull request introduces significant enhancements to the country (país) administration module, focusing on supporting the assignment and management of a country administrator ("Administrador") alongside the existing "Obrero Encargado". It also improves role-based access and UI behavior for the "ADMINISTRADOR_PAIS" role. Below are the most important changes:

### Administrator Assignment and Display

* Added support for assigning an administrator (`idAdministrador`) to a country in both the backend model (`CongregacionPaisModel`) and the country creation/editing form. The administrator can be searched by their "número Mita" and their name is displayed if found. [[1]](diffhunk://#diff-e4d1567a0b9fd211116fea1fec13ac4d1f34cd0ce386acf80f68d2d7be394d74L7-R8) Fb54aac4L35R45, [[2]](diffhunk://#diff-19f6b63ff4b70503aa614585ce515e20ed263ea7b8d9159ef74937589d8d4536L97-R144) [[3]](diffhunk://#diff-19f6b63ff4b70503aa614585ce515e20ed263ea7b8d9159ef74937589d8d4536L146-R187) [[4]](diffhunk://#diff-19f6b63ff4b70503aa614585ce515e20ed263ea7b8d9159ef74937589d8d4536R204-R250)
* Updated the country list UI to display the assigned administrator for each country, including their name and "número Mita". The search/filter placeholder now includes "administrador". [[1]](diffhunk://#diff-3fcab1edebac0587311ca92ab1e7f165ea48fddcd12be5d968e6d54c52ba415bL59-R62) [[2]](diffhunk://#diff-3fcab1edebac0587311ca92ab1e7f165ea48fddcd12be5d968e6d54c52ba415bR90) [[3]](diffhunk://#diff-3fcab1edebac0587311ca92ab1e7f165ea48fddcd12be5d968e6d54c52ba415bR106-R117) [[4]](diffhunk://#diff-3fcab1edebac0587311ca92ab1e7f165ea48fddcd12be5d968e6d54c52ba415bR159)

### Role-based Access and UI Adjustments

* The "ADMINISTRADOR_PAIS" role now sees only their assigned country in the country list, cannot create new countries, and has restricted access to certain actions (e.g., cannot delete or activate countries). [[1]](diffhunk://#diff-19f6b63ff4b70503aa614585ce515e20ed263ea7b8d9159ef74937589d8d4536L60-R100) [[2]](diffhunk://#diff-3fcab1edebac0587311ca92ab1e7f165ea48fddcd12be5d968e6d54c52ba415bL14-R21) [[3]](diffhunk://#diff-3fcab1edebac0587311ca92ab1e7f165ea48fddcd12be5d968e6d54c52ba415bL119-R141)
* In the country form, the "País" input and "Obrero Encargado" select are now read-only/disabled for "ADMINISTRADOR_PAIS" users. [[1]](diffhunk://#diff-ae7bd0ce9c772db05ef6663102c6c40c5305efe2e96c2c5e21499d768f35961dL5-R17) [[2]](diffhunk://#diff-ae7bd0ce9c772db05ef6663102c6c40c5305efe2e96c2c5e21499d768f35961dL26-R36)

### Role Definitions and Permissions

* Updated role arrays in `seccion-home.interface.ts` to include "ADMINISTRADOR_PAIS" where appropriate, ensuring these users see the correct sections in the home/dashboard. [[1]](diffhunk://#diff-0042156edfb101badc7ca57e9aacf1c28ab3c5e2bc7e7f93818659b8c3efe696R21) [[2]](diffhunk://#diff-0042156edfb101badc7ca57e9aacf1c28ab3c5e2bc7e7f93818659b8c3efe696R40) [[3]](diffhunk://#diff-0042156edfb101badc7ca57e9aacf1c28ab3c5e2bc7e7f93818659b8c3efe696L101-R103)

### Developer and Debugging Improvements

* Added console logs in `RolesGuard` for better debugging of permission checks.

These changes collectively improve the flexibility and security of country management, especially for the new "ADMINISTRADOR_PAIS" role, and enhance the user experience for administrators.